### PR TITLE
Hides IE10 builtin cross

### DIFF
--- a/textClearStyle.css
+++ b/textClearStyle.css
@@ -8,3 +8,6 @@
 .noTextClear {	
 	padding-right: 1%;
 }
+input::-ms-clear {
+    display: none;
+}


### PR DESCRIPTION
On IE10, both the built-in cross and the plug-in image are shown. This line of CSS hides the built-in one, so that all browsers should work the same.
